### PR TITLE
NYT-Obamaphone Carlos Slim

### DIFF
--- a/Obamaphone Carlos Slim
+++ b/Obamaphone Carlos Slim
@@ -1,0 +1,397 @@
+<!DOCTYPE html>
+
+<html lang="en-us">
+
+<head>
+
+    <meta charset="utf-8">
+
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+
+    <title>New York Times API</title>
+
+    <link href="https://cdnjs.cloudflare.com/ajax/libs/meyer-reset/2.0/reset.css" rel="stylesheet">
+
+    <!-- Latest compiled and minified CSS -->
+
+<link href="https://maxcdn.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css" rel="stylesheet" integrity="sha384-wvfXpqpZZVQGK6TAh5PVlGOfQNHSoD2xbE+QkPxCAFlNEevoEH3Sl0sibVcOQVnN" crossorigin="anonymous">
+
+<!-- Latest compiled and minified CSS -->
+
+<link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.7/css/bootstrap.min.css" integrity="sha384-BVYiiSIFeK1dGmJRAkycuHAHRg32OmUcww7on3RYdg4Va+PmSTsz/K68vbdEjh4u" crossorigin="anonymous">
+
+
+
+<script src="https://ajax.googleapis.com/ajax/libs/jquery/3.2.1/jquery.min.js"></script>
+
+
+
+</head>
+
+
+
+<style>
+
+
+
+    .side {
+
+    width: 1035px;
+
+    height: 35px;
+
+    font-weight: bold;
+
+    background-color: transparent;
+
+
+
+    }
+
+
+
+
+
+    #jTron {
+
+        text-align: center;
+
+        background-color: navy;
+
+        color: white;
+
+    }
+
+    .jumbotron {
+
+        background-color: navy;
+
+    }
+
+
+
+    .square {
+
+    width: 35px;
+
+    font-size: 25px;
+
+    color: white;
+
+    font-weight: bold;
+
+    background-color: navy;
+
+    display: block;
+
+    float: left;
+
+    }
+
+
+
+</style>
+
+
+
+<script>
+
+//VARIABLES
+
+
+
+var query = "Obamaphone Carlos Slim";
+
+var pageNo = 10;
+
+var begin = "01011980";
+
+var end = "07142017";
+
+var head = "";
+
+var snip = "";
+
+var date = "";
+
+var author = "";
+
+var link = "";
+
+var nytApiKey = "eafa397532be49299f095815f8165bde";
+
+
+
+
+
+  function queryNYT(){
+
+    var p = 0;
+
+    var url = "https://api.nytimes.com/svc/search/v2/articlesearch.json";
+
+    //url += "?" + "api-key=eafa397532be49299f095815f8165bde&q=";
+
+    //url += query + "&page=" + pageNo + "&begin_date=" + begin + "&end_date=" + end;
+
+
+
+    console.log ("Vamos a ver Variable: "+query);
+
+
+
+  $.ajax({
+
+
+
+    'type': 'GET',
+
+    'url': 'http://api.nytimes.com/svc/search/v2/articlesearch.json',
+
+    data: {
+
+        'q': query,
+
+        'fq': pageNo,
+
+        'begin_date':begin,
+
+        'end_date':end,
+
+        'sort':"newest",
+
+        'response-format': "jsonp",
+
+        'api-key': nytApiKey,
+
+        'callback': 'svc_search_v2_articlesearch'
+
+     },
+
+        success: function(data) {
+
+         console.log(data);
+
+
+
+         for (var i = 0; i < pageNo; i++) {
+
+
+
+           p = i + 1;
+
+
+
+           $('#grid-search').append('<p align = "center" class="square">'+p+'</p>');
+
+
+
+           $('#grid-search').append('<h3 class = "side">'+data.response.docs[i].headline.main.trim())+'</h3>';
+
+           $('#grid-search').append('<br>');
+
+           $('#grid-search').append("Section: "+data.response.docs[i].section_name);
+
+           $('#grid-search').append('<br>');
+
+           $('#grid-search').append(data.response.docs[i].pub_date);
+
+           $('#grid-search').append('<br>');
+
+
+
+           $('<a>',{
+
+                text: data.response.docs[i].web_url,
+
+                href: data.response.docs[i].web_url,
+
+            }).appendTo('#grid-search');
+
+            $('#grid-search').append('<br>');
+
+            $('#grid-search').append('<br>');
+
+
+
+           //$('#grid-search').append("Link: "+data.response.docs[i].web_url);
+
+          }
+
+
+
+     },
+
+        error: function(){
+
+       // alert("whoops ! something went wrng. Time go SO.")
+
+     }
+
+  });
+
+
+
+}
+
+
+
+$(document).ready(function(){
+
+
+
+        $("#searchBtn").on("click", function() {
+
+            queryNYT();
+
+        });
+
+
+
+        $("#clearBtn").on("click", function() {
+
+            $("#grid-search").empty();
+
+        });
+
+
+
+});
+
+
+
+</script>
+
+
+
+<body>
+
+
+
+<div class="container">
+
+    <div class="jumbotron">
+
+            <h1 id="jTron">
+
+                        <i class="fa fa-newspaper-o" aria-hidden="true"></i>
+
+        New York Times Search
+
+        </h1>
+
+    </div>
+
+    <div class="row">
+
+
+
+        <div class="col-lg-12">
+
+
+
+            <!--Search Parameters Panel -->
+
+            <div class="panel panel-default">
+
+                <div class="panel-heading">
+
+                    <h3 class="panel-title">Search Parameters</h3>
+
+                </div>
+
+            </div>
+
+         </div>
+
+    </div>
+
+    <div class="panel-body">
+
+                    <form>
+
+                        <div class="form-group">
+
+                            <label for="search">Search Term:</label>
+
+                            <input type="text" class="form-control" id="search">
+
+                        </div>
+
+                        <div class="form-group">
+
+                            <label for="sel1">Records to Retrieve:</label>
+
+                            <select class="form-control" id="sel1">
+
+                                <option value=1>1</option>
+
+                                <option value=5 selected>5</option>
+
+                                <option value=10>10</option>
+
+                              </select>
+
+                        </div>
+
+                        <div class="form-group">
+
+                            <label for="startYear">Start Year(Optional):</label>
+
+                            <input type="text" class="form-control" id="startYear">
+
+                        </div>
+
+                        <div class="form-group">
+
+                            <label for="endYear">End Year(Optional):</label>
+
+                            <input type="text" class="form-control" id="endYear">
+
+                        </div>
+
+                   </form>
+
+            </div>
+
+
+
+  <button type="submit" class="btn btn-default" id="searchBtn">Search</button>
+
+  <button type="submit" class="btn btn-default" id="clearBtn">Clear</button>
+
+  <div class="row">
+
+            <div class="col-lg-12">
+
+                <div class="panel panel-default">
+
+                    <div class="panel-heading">
+
+                        <h3 class="panel-title">Search Results</h3>
+
+                    </div>
+
+                    <div class="panel-body">
+
+                        <div id="grid-search">
+
+
+
+                        </div>
+
+                    </div>
+
+                </div>
+
+            </div>
+
+
+
+ <!-- <div id = "grid-search"></div> -->
+
+
+
+</div>
+
+</body>


### PR DESCRIPTION
Trying to see if NYT has any news searches on these topics. I guess its selective opinion articles only not actual news. 
http://www.huffingtonpost.com/2012/10/10/carlos-slim-obamaphones_n_1955929.html
http://www.washingtontimes.com/news/2017/jun/29/obamaphone-program-riddled-fraud-audit/
http://www.edmondsun.com/news/local_news/defendant-sentenced-to-months-in-prison-for-money-laundering/article_66c9ea4a-eb0a-11e4-8f98-5b7201e21d49.html 
http://freebeacon.com/issues/mexican-billionaire-carlos-slim-becomes-top-owner-of-new-york-times/